### PR TITLE
@countpaulis and @peakpaulis macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ All of the above can be addressed by writing the additional missing code due to 
 Starting with version `0.8`, we provide an `mcpropagate(...; max_size)` function. It propagates as usual, truncates if you pass truncation parameters, and when the number of terms exceeds `max_size`, it resamples down to a `resampling_size` (default `max_size / 2`) via an unbiased procedure. This in principle allows one to arbitrarily trade memory for averaging time, but note that all coefficients become increasingly large and inaccurate the more often it must resample. See the `mcpropagate.ipynb` notebook in the examples folder.
 
 
+## Counting Pauli Strings
+To inspect how many Pauli strings a propagation creates, prefix any expression that propagates with `@countpaulis` or `@peakpaulis`:
+
+```julia
+counts = @countpaulis psum = propagate(circuit, observable, parameters; min_abs_coeff)
+peak = @peakpaulis rewindgradient(circuit, observable, parameters, overlapwithzero)
+```
+
+`@countpaulis` returns the number of Pauli strings after every applied gate (after merging and truncating), and `@peakpaulis` returns only the maximum. Both work with any function that propagates internally, including `propagate(...)`, `propagate!(...)`, `mcpropagate(...)`, and `rewindgradient(...)`. Importantly, tracking a function that multi-threads over parallel propagations can yield unexpected results.
+
 ## Yao.jl integration
 
 Load `Yao` or `YaoBlocks` together with `PauliPropagation` to convert observables to Yao blocks:

--- a/src/Base/Base.jl
+++ b/src/Base/Base.jl
@@ -62,6 +62,8 @@ export
     ParametrizedGate,
     countparameters
 
+include("./countterms.jl")
+
 include("./propagate.jl")
 export propagate,
     propagate!,

--- a/src/Base/countterms.jl
+++ b/src/Base/countterms.jl
@@ -1,0 +1,63 @@
+###
+##
+# Counting how many terms a propagation carries, as `@countpaulis` and `@peakpaulis` do.
+# `_propagate!` calls `_recordsize!` after every gate, which does nothing unless a counter is installed.
+##
+###
+
+"""
+    pushcounter!(counts::Vector{Int})
+    popcounter!(counts::Vector{Int})
+
+Start and stop appending the number of terms after every gate of every propagation to `counts`.
+Counters stack, so an outer one also sees the gates seen by an inner one.
+"""
+function pushcounter!(counts::Vector{Int})
+    lock(_COUNTERLOCK) do
+        push!(_COUNTERS, counts)
+    end
+    return counts
+end
+
+function popcounter!(counts::Vector{Int})
+    lock(_COUNTERLOCK) do
+        idx = findlast(c -> c === counts, _COUNTERS)
+        isnothing(idx) || deleteat!(_COUNTERS, idx)
+    end
+    return counts
+end
+
+# Global because propagations are reached through arbitrarily deep call stacks,
+# locked because several of them may run concurrently.
+const _COUNTERS = Vector{Int}[]
+const _COUNTERLOCK = ReentrantLock()
+
+@inline function _recordsize!(target)
+    # the common case is no counter at all, which must stay free
+    isempty(_COUNTERS) && return
+    _pushsize!(target)
+    return
+end
+
+@noinline function _pushsize!(target)
+    n = _termcount(target)
+    isnothing(n) && return
+
+    lock(_COUNTERLOCK) do
+        for counts in _COUNTERS
+            push!(counts, n)
+        end
+    end
+
+    return
+end
+
+"""
+    _termcount(target)
+
+The number of terms currently held by whatever `_propagate!` carries between gates,
+or `nothing` if that is not something with a term count.
+Overload this for custom propagation states.
+"""
+_termcount(target::Union{AbstractPropagationCache,AbstractTermSum}) = length(target)
+_termcount(target) = nothing

--- a/src/Base/countterms.jl
+++ b/src/Base/countterms.jl
@@ -5,6 +5,16 @@
 ##
 ###
 
+# Global because propagations are reached through arbitrarily deep call stacks.
+# The stack of installed counters is an immutable snapshot behind an atomic field,
+# so the common no-counter check is a race-free single load; the lock serializes everything else.
+mutable struct _CounterStack
+    @atomic stack::Tuple{Vararg{Vector{Int}}}
+    const lock::ReentrantLock
+end
+
+const _COUNTERS = _CounterStack((), ReentrantLock())
+
 """
     pushcounter!(counts::Vector{Int})
     popcounter!(counts::Vector{Int})
@@ -13,28 +23,24 @@ Start and stop appending the number of terms after every gate of every propagati
 Counters stack, so an outer one also sees the gates seen by an inner one.
 """
 function pushcounter!(counts::Vector{Int})
-    lock(_COUNTERLOCK) do
-        push!(_COUNTERS, counts)
+    lock(_COUNTERS.lock) do
+        @atomic _COUNTERS.stack = ((@atomic _COUNTERS.stack)..., counts)
     end
     return counts
 end
 
 function popcounter!(counts::Vector{Int})
-    lock(_COUNTERLOCK) do
-        idx = findlast(c -> c === counts, _COUNTERS)
-        isnothing(idx) || deleteat!(_COUNTERS, idx)
+    lock(_COUNTERS.lock) do
+        stack = @atomic _COUNTERS.stack
+        idx = findlast(c -> c === counts, stack)
+        isnothing(idx) || @atomic _COUNTERS.stack = (stack[1:idx-1]..., stack[idx+1:end]...)
     end
     return counts
 end
 
-# Global because propagations are reached through arbitrarily deep call stacks,
-# locked because several of them may run concurrently.
-const _COUNTERS = Vector{Int}[]
-const _COUNTERLOCK = ReentrantLock()
-
 @inline function _recordsize!(target)
     # the common case is no counter at all, which must stay free
-    isempty(_COUNTERS) && return
+    isempty(@atomic _COUNTERS.stack) && return
     _pushsize!(target)
     return
 end
@@ -43,8 +49,8 @@ end
     n = _termcount(target)
     isnothing(n) && return
 
-    lock(_COUNTERLOCK) do
-        for counts in _COUNTERS
+    lock(_COUNTERS.lock) do
+        for counts in (@atomic _COUNTERS.stack)
             push!(counts, n)
         end
     end
@@ -61,3 +67,30 @@ Overload this for custom propagation states.
 """
 _termcount(target::Union{AbstractPropagationCache,AbstractTermSum}) = length(target)
 _termcount(target) = nothing
+
+_peak(counts) = maximum(counts; init=0)
+
+# Shared expansion for `@countpaulis`-style macros; downstream packages build theirs from this.
+# Interpolating the functions as values keeps the expansion independent of the caller's module.
+# A leading assignment is peeled off and performed outside the `try` block, because `try` opens a
+# soft local scope in which assignments to new variables would not reach the calling scope.
+function _countingexpr(expr, reducefunc)
+    is_assignment = isa(expr, Expr) && expr.head === :(=)
+    lhs = is_assignment ? expr.args[1] : nothing
+    rhs = is_assignment ? expr.args[2] : expr
+
+    counts = gensym(:counts)
+    value = gensym(:value)
+    assignment = is_assignment ? Expr(:(=), esc(lhs), value) : nothing
+
+    return quote
+        local $counts = $pushcounter!(Int[])
+        local $value = try
+            $(esc(rhs))
+        finally
+            $popcounter!($counts)
+        end
+        $assignment
+        $reducefunc($counts)
+    end
+end

--- a/src/Base/propagate.jl
+++ b/src/Base/propagate.jl
@@ -60,6 +60,9 @@ function _propagate!(stepfunc::F, circuit, target, params=nothing; kwargs...) wh
         else
             stepfunc(gate, target; kwargs...)
         end
+
+        # free unless `@countpaulis` or `@peakpaulis` installed a counter
+        _recordsize!(target)
     end
 
     return target

--- a/src/PauliPropagation.jl
+++ b/src/PauliPropagation.jl
@@ -155,6 +155,12 @@ export
     resample!
 
 
+include("countpaulis.jl")
+export
+    @countpaulis,
+    @peakpaulis
+
+
 include("PathProperties/PathProperties.jl")
 export
     PathProperties,

--- a/src/countpaulis.jl
+++ b/src/countpaulis.jl
@@ -1,0 +1,64 @@
+"""
+    @countpaulis expr
+    @countpaulis lhs = expr
+
+Return the number of Pauli strings after every gate applied inside `expr`, as a `Vector{Int}`.
+
+Counts are taken after merging and truncating, and are ordered as the gates are applied,
+which for the default Heisenberg picture is the reverse of the circuit as written.
+Every propagation inside `expr` contributes, including `mcpropagate`, `mcsample` and `rewindgradient`.
+An assignment is instrumented by prefixing it, and still assigns.
+
+```julia
+counts = @countpaulis propagate(circuit, psum, thetas)
+counts = @countpaulis psum = propagate(circuit, psum, thetas)
+```
+"""
+macro countpaulis(expr)
+    return _countingexpr(expr, :identity)
+end
+
+"""
+    @peakpaulis expr
+    @peakpaulis lhs = expr
+
+Return the largest number of Pauli strings held after any gate applied inside `expr`, or `0` if nothing was propagated.
+
+`expr` is typically a call to a function that propagates internally, possibly several times,
+in which case the peak is taken over all of those propagations.
+See `@countpaulis` for what is counted and when.
+
+```julia
+peak = @peakpaulis myexpectationvalue(circuit, thetas)
+peak = @peakpaulis psum, base = headandtails(circuit, obs, thetas, nlayers)
+```
+"""
+macro peakpaulis(expr)
+    return _countingexpr(expr, :_peak)
+end
+
+_peak(counts) = maximum(counts; init=0)
+
+# Evaluate `expr` with a counter installed and reduce what it counted.
+# A leading assignment is peeled off and performed outside the `try` block, because `try` opens a
+# soft local scope in which assignments to new variables would not reach the calling scope.
+function _countingexpr(expr, reducefunc)
+    is_assignment = isa(expr, Expr) && expr.head === :(=)
+    lhs = is_assignment ? expr.args[1] : nothing
+    rhs = is_assignment ? expr.args[2] : expr
+
+    counts = gensym(:counts)
+    value = gensym(:value)
+    assignment = is_assignment ? Expr(:(=), esc(lhs), value) : nothing
+
+    return quote
+        local $counts = PropagationBase.pushcounter!(Int[])
+        local $value = try
+            $(esc(rhs))
+        finally
+            PropagationBase.popcounter!($counts)
+        end
+        $assignment
+        $reducefunc($counts)
+    end
+end

--- a/src/countpaulis.jl
+++ b/src/countpaulis.jl
@@ -15,7 +15,7 @@ counts = @countpaulis psum = propagate(circuit, psum, thetas)
 ```
 """
 macro countpaulis(expr)
-    return _countingexpr(expr, :identity)
+    return PropagationBase._countingexpr(expr, identity)
 end
 
 """
@@ -34,31 +34,5 @@ peak = @peakpaulis psum, base = headandtails(circuit, obs, thetas, nlayers)
 ```
 """
 macro peakpaulis(expr)
-    return _countingexpr(expr, :_peak)
-end
-
-_peak(counts) = maximum(counts; init=0)
-
-# Evaluate `expr` with a counter installed and reduce what it counted.
-# A leading assignment is peeled off and performed outside the `try` block, because `try` opens a
-# soft local scope in which assignments to new variables would not reach the calling scope.
-function _countingexpr(expr, reducefunc)
-    is_assignment = isa(expr, Expr) && expr.head === :(=)
-    lhs = is_assignment ? expr.args[1] : nothing
-    rhs = is_assignment ? expr.args[2] : expr
-
-    counts = gensym(:counts)
-    value = gensym(:value)
-    assignment = is_assignment ? Expr(:(=), esc(lhs), value) : nothing
-
-    return quote
-        local $counts = PropagationBase.pushcounter!(Int[])
-        local $value = try
-            $(esc(rhs))
-        finally
-            PropagationBase.popcounter!($counts)
-        end
-        $assignment
-        $reducefunc($counts)
-    end
+    return PropagationBase._countingexpr(expr, PropagationBase._peak)
 end

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -96,6 +96,9 @@ mutable struct _BackwardSweepState{OC,DC}
     commutator_buffer::Vector{ComplexF64}
 end
 
+# the backward sweep is carried by this state instead of a cache, so count the operator sum
+PropagationBase._termcount(state::_BackwardSweepState) = length(state.op_cache)
+
 # Records the gradient component for PauliRotation
 function _undostep!(gate::PauliRotation, state::_BackwardSweepState, theta; thread::Bool=true, kwargs...)
     gate_mask = symboltoint(state.nq, gate.symbols, gate.qinds)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,8 @@ using Random
 
     include("test_numericalcertificates.jl")
 
+    include("test_countpaulis.jl")
+
     include("test_visualization.jl")
 
     include("test_gates_against_yao.jl")

--- a/test/test_countpaulis.jl
+++ b/test/test_countpaulis.jl
@@ -1,0 +1,120 @@
+using Random
+
+
+@testset "Test @countpaulis" begin
+
+    nq = 6
+    nl = 3
+    min_abs_coeff = 1e-8
+
+    pstr = PauliString(nq, :Z, 3)
+    circ = hardwareefficientcircuit(nq, nl; topology=bricklayertopology(nq; periodic=false))
+
+    Random.seed!(42)
+    thetas = randn(countparameters(circ))
+
+    counts = @countpaulis propagate(circ, pstr, thetas; min_abs_coeff)
+
+    # one count per gate, and the last one is the size of the propagated sum
+    @test length(counts) == length(circ)
+    @test counts[end] == length(propagate(circ, pstr, thetas; min_abs_coeff))
+
+    # the counts are exactly what applying the circuit gate by gate produces
+    psum = PauliSum(pstr)
+    manual_counts = Int[]
+    theta_iterator = Iterators.Stateful(reverse(thetas))
+    for gate in reverse(circ)
+        if isa(gate, ParametrizedGate)
+            propagate!(gate, psum, popfirst!(theta_iterator); min_abs_coeff)
+        else
+            propagate!(gate, psum; min_abs_coeff)
+        end
+        push!(manual_counts, length(psum))
+    end
+    @test manual_counts == counts
+
+    # the vector backend takes the same path through the circuit
+    @test (@countpaulis propagate(circ, VectorPauliSum(pstr), thetas; min_abs_coeff)) == counts
+
+    # in-place propagation is counted too, and keeps the propagated sum
+    psum = PauliSum(pstr)
+    @test (@countpaulis propagate!(circ, psum, thetas; min_abs_coeff)) == counts
+    @test length(psum) == counts[end]
+
+    # an instrumented assignment still assigns, in the scope the macro was written in
+    assigned_counts = @countpaulis propagated = propagate(circ, pstr, thetas; min_abs_coeff)
+    @test assigned_counts == counts
+    @test length(propagated) == counts[end]
+
+    # the Schrödinger picture is counted the same way
+    @test length(@countpaulis propagate(circ, pstr, thetas; min_abs_coeff, heisenberg=false)) == length(circ)
+
+    # Monte Carlo propagation and sampling go through the same gate loop
+    @test length(@countpaulis mcpropagate(circ, VectorPauliSum(pstr), thetas; max_size=100)) == length(circ)
+    @test length(@countpaulis mcsample(circ, pstr, thetas)) == length(circ)
+
+    # a truncation that keeps nothing leaves empty sums behind, not missing counts
+    empty_counts = @countpaulis propagate(circ, pstr, thetas; min_abs_coeff=1e10)
+    @test length(empty_counts) == length(circ)
+    @test all(iszero, empty_counts)
+
+    # nothing to count
+    @test (@countpaulis 1 + 1) == Int[]
+
+end
+
+@testset "Test @peakpaulis" begin
+
+    nq = 6
+    nl = 3
+    min_abs_coeff = 1e-8
+
+    pstr = PauliString(nq, :Z, 3)
+    circ = hardwareefficientcircuit(nq, nl; topology=bricklayertopology(nq; periodic=false))
+
+    Random.seed!(42)
+    thetas = randn(countparameters(circ))
+
+    counts = @countpaulis propagate(circ, pstr, thetas; min_abs_coeff)
+
+    @test (@peakpaulis propagate(circ, pstr, thetas; min_abs_coeff)) == maximum(counts)
+
+    # the peak runs over every propagation inside the expression
+    function twopropagations(circ, thetas)
+        short_circ = circ[1:2]
+        propagate(short_circ, pstr, thetas[1:countparameters(short_circ)]; min_abs_coeff)
+        return propagate(circ, pstr, thetas; min_abs_coeff)
+    end
+    @test (@peakpaulis twopropagations(circ, thetas)) == maximum(counts)
+
+    # gradients propagate forwards and then backwards
+    @test (@peakpaulis rewindgradient(circ, VectorPauliSum(pstr), thetas, overlapwithzero; min_abs_coeff)) >= maximum(counts)
+
+    # nothing propagated
+    @test (@peakpaulis 1 + 1) == 0
+
+    # counters stack, so the outer one sees what the inner one counts
+    @test (@peakpaulis (@countpaulis propagate(circ, pstr, thetas; min_abs_coeff))) == maximum(counts)
+
+    # a destructuring assignment is instrumented without swallowing its left-hand side
+    function tworeturns(circ, thetas)
+        return propagate(circ, pstr, thetas; min_abs_coeff), :marker
+    end
+    peak = @peakpaulis propagated, marker = tworeturns(circ, thetas)
+    @test peak == maximum(counts)
+    @test length(propagated) == counts[end]
+    @test marker == :marker
+
+    # the same inside a function, where the assignment is to a fresh local
+    function peakandsize(circ, thetas)
+        peak = @peakpaulis psum = propagate(circ, pstr, thetas; min_abs_coeff)
+        return peak, length(psum)
+    end
+    @test peakandsize(circ, thetas) == (maximum(counts), counts[end])
+
+    # a counter is uninstalled again even when the expression throws
+    @test_throws ErrorException @peakpaulis error("propagation failed")
+    @test_throws ErrorException @peakpaulis failed = error("propagation failed")
+    @test (@peakpaulis 1 + 1) == 0
+
+end


### PR DESCRIPTION
Hook into lower-level propagation to track the number of Pauli strings per gate application. Described by README:

## Counting Pauli Strings
To inspect how many Pauli strings a propagation creates, prefix any expression that propagates with `@countpaulis` or `@peakpaulis`:

```julia
counts = @countpaulis psum = propagate(circuit, observable, parameters; min_abs_coeff)
peak = @peakpaulis rewindgradient(circuit, observable, parameters, overlapwithzero)
```

`@countpaulis` returns the number of Pauli strings after every applied gate (after merging and truncating), and `@peakpaulis` returns only the maximum. Both work with any function that propagates internally, including `propagate(...)`, `propagate!(...)`, `mcpropagate(...)`, and `rewindgradient(...)`. Importantly, tracking a function that multi-threads over parallel propagations can yield unexpected results.