### PR TITLE
Add a Complex specialization of truncatemincoeff via abs2

### DIFF
--- a/src/truncations.jl
+++ b/src/truncations.jl
@@ -65,6 +65,15 @@ function truncatemincoeff(coeff::Number, min_abs_coeff::Real)
 end
 
 
+# Complex specialization, compared via the squares: `abs2` avoids the overflow-safe
+# `hypot` inside `abs` (~5-12x cheaper and SIMD-able; the dominant cost of the
+# truncation pass on large vector-backend sums). For real coefficients `abs` is a
+# single instruction, so only `Complex` benefits.
+function truncatemincoeff(coeff::Complex, min_abs_coeff::Real)
+    return abs2(coeff) < min_abs_coeff^2
+end
+
+
 # Return `true` if `abs(path_property.coeff) < min_abs_coeff`. 
 function truncatemincoeff(path_property::PProp, min_abs_coeff::Real) where {PProp<:PathProperties}
     if hasfield(PProp, :coeff)

--- a/src/truncations.jl
+++ b/src/truncations.jl
@@ -74,10 +74,11 @@ function truncatemincoeff(coeff::Complex, min_abs_coeff::Real)
 end
 
 
-# Return `true` if `abs(path_property.coeff) < min_abs_coeff`. 
+# Return `true` if `abs(path_property.coeff) < min_abs_coeff`, delegating to the method
+# for the wrapped coefficient's type (so e.g. a complex coeff gets the abs2 fast path).
 function truncatemincoeff(path_property::PProp, min_abs_coeff::Real) where {PProp<:PathProperties}
     if hasfield(PProp, :coeff)
-        return abs(path_property.coeff) < min_abs_coeff
+        return truncatemincoeff(path_property.coeff, min_abs_coeff)
     else
         return false
     end

--- a/src/truncations.jl
+++ b/src/truncations.jl
@@ -59,23 +59,22 @@ function truncatemincoeff(coeff, min_abs_coeff::Real)
 end
 
 
-# Return `true` if `abs(coeff) < min_abs_coeff`. 
+# For general number types, simply use `abs`.
 function truncatemincoeff(coeff::Number, min_abs_coeff::Real)
     return abs(coeff) < min_abs_coeff
 end
 
 
-# Complex specialization, compared via the squares: `abs2` avoids the overflow-safe
-# `hypot` inside `abs` (~5-12x cheaper and SIMD-able; the dominant cost of the
-# truncation pass on large vector-backend sums). For real coefficients `abs` is a
-# single instruction, so only `Complex` benefits.
+# Complex specialization: `abs2` avoids the overflow-safe `hypot` inside `abs`.
+# Is ~5-12x cheaper and SIMD-able. 
+# For real coefficients `abs` is a single instruction, so only `Complex` benefits.
 function truncatemincoeff(coeff::Complex, min_abs_coeff::Real)
     return abs2(coeff) < min_abs_coeff^2
 end
 
 
-# Return `true` if `abs(path_property.coeff) < min_abs_coeff`, delegating to the method
-# for the wrapped coefficient's type (so e.g. a complex coeff gets the abs2 fast path).
+# Delegating to the `truncatemincoeff` method for the wrapped coefficient's type.
+# If the `PathProperties` type does not have a `coeff` field, it defaults to `false`.
 function truncatemincoeff(path_property::PProp, min_abs_coeff::Real) where {PProp<:PathProperties}
     if hasfield(PProp, :coeff)
         return truncatemincoeff(path_property.coeff, min_abs_coeff)


### PR DESCRIPTION
## Summary

`abs(::Complex)` goes through the overflow-safe `hypot` (rescaling + `sqrt` + non-finiteness checks), which dominates the `min_abs_coeff` flag pass on large vector-backend sums with complex coefficients — ~3% of total wall in a downstream Trotter workload (FermionicPropagation, 18-site Hubbard, ~15M-term `ComplexF64` sums).

This PR adds a `Complex` specialization of `truncatemincoeff` that compares the squares instead:

```julia
function truncatemincoeff(coeff::Complex, min_abs_coeff::Real)
    return abs2(coeff) < min_abs_coeff^2
end
```

Only `Complex` gets the specialization: for real coefficients `abs` is a single instruction, so the generic `Number` method keeps its exact current behavior.

The `PathProperties` method now delegates to `truncatemincoeff(path_property.coeff, min_abs_coeff)` instead of hard-coding `abs`: real coeffs (all shipped `PathProperties` types) are bit-identical to before, a complex coeff reaches the `abs2` fast path, and future coefficient-type specializations apply to wrapped coefficients automatically. A non-`Number` coeff now hits the unsuitable-type fallback (`false`) instead of a `MethodError` on `abs`.

## Measurements

- Predicate pass over 2M `ComplexF64`: 5.07 ms → 0.41 ms (**12×**) — `abs2` also lets the loop SIMD-vectorize, which `hypot`'s branches prevent.
- Semantics differ from `abs` only for `|coeff|` beyond ~1e154, where `abs2` saturates to `Inf` (the term is kept, which is the correct outcome there anyway).

## Test plan

- 300M-sample fuzz of `abs(c) < m` vs `abs2(c) < m^2` over ~40 decades of magnitude and thresholds `{0, 1e-10, 1e-3, 1, Inf}`, including ulp-adjacent edge values: zero disagreements.
- Full test suite on this branch: 5140/5140 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
