### PR TITLE
Performance: single-pass fused apply for VectorPauliSum rotations and noise

### DIFF
--- a/src/Base/vectorbackend.jl
+++ b/src/Base/vectorbackend.jl
@@ -10,6 +10,17 @@
     return pos + 1
 end
 
+# Moves each task's block src[start_t : start_t + count_t - 1] to dst[dst_base + offset_t : ...], where
+# start_t is the task's partition start and offset_t comes from `_offsetsfromcounts(counts)`. The
+# destinations are dense and disjoint and src is a different array, so the tasks run in parallel.
+function _compactblocks!(dst_terms, dst_coeffs, src_terms, src_coeffs, task_partitioner, n_tasks::Int, counts, offsets, dst_base::Int)
+    AK.itask_partition(n_tasks, n_tasks, 1) do task_id, _
+        _copyblock!(dst_terms, dst_coeffs, src_terms, src_coeffs,
+            dst_base + offsets[task_id], task_partitioner[task_id].start, counts[task_id])
+    end
+    return nothing
+end
+
 function sortbyterm!(prop_cache::AbstractPropagationCache; lt=isless, by=identity, rev=false, order=Base.Forward, thread::Bool=true)
 
     # if terms are are not native data types, sorting kwargs need to be provided

--- a/src/Performance/fused_vector.jl
+++ b/src/Performance/fused_vector.jl
@@ -100,48 +100,42 @@ function _fusedrotation!(gate, prop_cache, kept_val, new_val, gatetype::Val;
     return prop_cache
 end
 
-# Counts each task's products in a first pass, then writes them in a second.
+# One pass: each task writes its products into its own stretch of the aux arrays, then the stretches
+# are compacted onto the end of the main arrays.
 function _fusedapplytruncaterotation!(prop_cache::PauliPropagation.VectorPauliPropagationCache, gate_mask::TT, kept_val, new_val, max_weight, ::Val{GateType};
     thread::Bool=true) where {TT,GateType}
 
     n_old = activesize(prop_cache)
 
     task_partitioner, n_tasks = PropagationBase._preparetasks(n_old, thread)
-    main_terms, main_coeffs, _, _ = PropagationBase._mainauxarrays(prop_cache)
+    main_terms, main_coeffs, aux_terms, aux_coeffs = PropagationBase._mainauxarrays(prop_cache)
 
     new_counts = Vector{Int}(undef, n_tasks)
 
-    # dry run: each task counts the products it will append, without writing
+    # a term makes at most one product, so a task's products fit in aux over its own range, which
+    # tells every task where to write before any of them has walked; aux is sized like main
     AK.itask_partition(n_tasks, n_tasks, 1) do task_id, _
         rng = task_partitioner[task_id]
-        new_counts[task_id] = _fusedbranchwrite!(main_terms, main_coeffs, 1, rng.start, rng.stop,
-            gate_mask, kept_val, new_val, max_weight, Val(GateType), Val(false))
+        new_counts[task_id] = _fusedbranchwrite!(aux_terms, aux_coeffs, main_terms, main_coeffs, rng.start, rng.stop,
+            gate_mask, kept_val, new_val, max_weight, Val(GateType))
     end
 
     new_offsets = PropagationBase._offsetsfromcounts(new_counts)
     n_new = new_offsets[end] - 1
 
-    # A term that branched had its coefficient scaled, so no products does not on its own mean there
-    # is nothing to write. Without a weight limit, though, no product is ever dropped, and then no
-    # products does mean nothing branched -- worth taking, because a gate the sum has not spread to
-    # yet branches nothing at all and would otherwise be walked twice over.
-    if n_new == 0 && isinf(max_weight)
+    # the branching coefficients are already scaled in place, so nothing is left to do
+    if n_new == 0
         return prop_cache
     end
 
+    # after the pass: the byte pointer read in `_fusedbranchwrite!` does not survive a resize
     resize_factor = 1.5
     if PauliPropagation.capacity(prop_cache) < n_old + n_new
         resize!(prop_cache, round(Int, (n_old + n_new) * resize_factor))
-        main_terms, main_coeffs, _, _ = PropagationBase._mainauxarrays(prop_cache)
     end
 
-    # real pass: scale the branching coefficients where they lie and append each task's products at
-    # its own offset past the end
-    AK.itask_partition(n_tasks, n_tasks, 1) do task_id, _
-        rng = task_partitioner[task_id]
-        _fusedbranchwrite!(main_terms, main_coeffs, n_old + new_offsets[task_id], rng.start, rng.stop,
-            gate_mask, kept_val, new_val, max_weight, Val(GateType), Val(true))
-    end
+    # append the products in parent order past the end of the main arrays
+    PropagationBase._compactblocks!(main_terms, main_coeffs, aux_terms, aux_coeffs, task_partitioner, n_tasks, new_counts, new_offsets, n_old)
 
     # the terms already there kept their Pauli strings and their order, so the sorted prefix stands
     setactivesize!(prop_cache, n_old + n_new)
@@ -155,13 +149,12 @@ end
 
 # Walks terms[lo:hi], branching each term according to `_branchcondition(Val(GateType), ...)`. A
 # branching term keeps its Pauli string and only has its coefficient scaled, so it stays where it is
-# and needs no test -- its weight already passed. Its product is appended from new_start, unless it
-# is too heavy, which merging cannot undo. When DoWrite is false nothing is written and the products
-# are only counted. Returns the number of products.
-@inline function _fusedbranchwrite!(terms, coeffs, new_start, lo, hi,
-    gate_mask::TT, kept_val, new_val, max_weight, ::Val{GateType}, ::Val{DoWrite}) where {TT,GateType,DoWrite}
+# and needs no test -- its weight already passed. Its product is written to out_terms/out_coeffs from
+# `lo`, unless it is too heavy, which merging cannot undo. Returns the number of products.
+@inline function _fusedbranchwrite!(out_terms, out_coeffs, terms, coeffs, lo, hi,
+    gate_mask::TT, kept_val, new_val, max_weight, ::Val{GateType}) where {TT,GateType}
 
-    new_pos = new_start
+    new_pos = lo
 
     # the pointer a ByteMask reads through is valid only inside this block
     GC.@preserve terms begin
@@ -174,16 +167,16 @@ end
             _branchcondition(Val(GateType), does_commute) || continue
 
             coeff = coeffs[ii]
-            DoWrite && (coeffs[ii] = coeff * kept_val)
+            coeffs[ii] = coeff * kept_val
 
             new_pstr, sign = _gateproduct(gate_mask, pstr, bytes, ii)
             if !_truncateweight(new_pstr, max_weight)
-                new_pos = PropagationBase._writeandadvance!(terms, coeffs, new_pos, new_pstr, coeff * new_val * sign, Val(DoWrite))
+                new_pos = PropagationBase._writeandadvance!(out_terms, out_coeffs, new_pos, new_pstr, coeff * new_val * sign, Val(true))
             end
         end
     end
 
-    return new_pos - new_start
+    return new_pos - lo
 end
 
 ### Pauli Noise
@@ -237,44 +230,43 @@ function _fusedapplytruncatenoise!(prop_cache::PauliPropagation.VectorPauliPropa
     kept_counts = Vector{Int}(undef, n_tasks)
     sorted_kept_counts = Vector{Int}(undef, n_tasks)
 
-    # dry run: each task counts its own surviving output size, without writing
+    # one pass: each task writes its survivors into aux over its own range, which is where they
+    # would land with nothing dropped; aux is sized like main
     AK.itask_partition(n_tasks, n_tasks, 1) do task_id, _
         rng = task_partitioner[task_id]
-        kept_counts[task_id], sorted_kept_counts[task_id] = _noisewrite!(aux_terms, aux_coeffs, 1,
-            main_terms, main_coeffs, rng.start, rng.stop, gate, qind, lambda, truncfunc, old_sortedprefix, Val(false))
+        kept_counts[task_id], sorted_kept_counts[task_id] = _noisewrite!(aux_terms, aux_coeffs,
+            main_terms, main_coeffs, rng.start, rng.stop, gate, qind, lambda, truncfunc, old_sortedprefix)
     end
 
-    # small serial prefix sum over just the per-task counts (mirrors sortedtailmerge!'s offset bookkeeping)
     kept_offsets = PropagationBase._offsetsfromcounts(kept_counts)
     n_kept = kept_offsets[end] - 1
     new_sortedprefix = sum(sorted_kept_counts)
 
-    # real pass: redo the same walk, now writing each task's output directly into its final position
-    AK.itask_partition(n_tasks, n_tasks, 1) do task_id, _
-        rng = task_partitioner[task_id]
-        _noisewrite!(aux_terms, aux_coeffs, kept_offsets[task_id],
-            main_terms, main_coeffs, rng.start, rng.stop, gate, qind, lambda, truncfunc, old_sortedprefix, Val(true))
-    end
+    # compact the survivors back into main, in their old order; no swap
+    PropagationBase._compactblocks!(main_terms, main_coeffs, aux_terms, aux_coeffs, task_partitioner, n_tasks, kept_counts, kept_offsets, 0)
 
-    PropagationBase._commitwrite!(prop_cache, n_kept, new_sortedprefix)
+    setactivesize!(prop_cache, n_kept)
+    setsortedprefix!(mainsum(prop_cache), new_sortedprefix)
 
     return prop_cache
 end
 
 
-@inline function _noisewrite!(out_terms, out_coeffs, out_start, terms, coeffs, lo, hi,
-    gate::PauliPropagation.PauliNoise, qind, lambda, truncfunc::F, old_sortedprefix::Int, ::Val{DoWrite}) where {F,DoWrite}
+# writes the survivors of terms[lo:hi] to out_terms/out_coeffs from `lo`; returns (survivors, of
+# which from the old sorted prefix)
+@inline function _noisewrite!(out_terms, out_coeffs, terms, coeffs, lo, hi,
+    gate::PauliPropagation.PauliNoise, qind, lambda, truncfunc::F, old_sortedprefix::Int) where {F}
 
-    pos = out_start
+    pos = lo
     n_sorted_kept = 0
     @inbounds for ii in lo:hi
         pstr = terms[ii]
         new_coeff = PauliPropagation.isdamped(gate, getpauli(pstr, qind)) ? coeffs[ii] * (1 - lambda) : coeffs[ii]
         if !truncfunc(pstr, new_coeff)
-            pos = PropagationBase._writeandadvance!(out_terms, out_coeffs, pos, pstr, new_coeff, Val(DoWrite))
+            pos = PropagationBase._writeandadvance!(out_terms, out_coeffs, pos, pstr, new_coeff, Val(true))
             ii <= old_sortedprefix && (n_sorted_kept += 1)
         end
     end
 
-    return (pos - out_start, n_sorted_kept)
+    return (pos - lo, n_sorted_kept)
 end

--- a/test/test_performance.jl
+++ b/test/test_performance.jl
@@ -286,3 +286,64 @@ end
     @test d_thread == d_nothread
     @test overlapwithzero(d_thread) == overlapwithzero(d_nothread)
 end
+
+@testset "fused Vector: branching with every product weight-dropped still scales the parents" begin
+    # every anticommuting term branches, but each product exceeds max_weight, so the fused apply
+    # appends nothing and must still leave the parents scaled by cos(theta)
+    theta = 0.7
+
+    # single task: X1 anticommutes with Z1 X2; the product Y1 X2 has weight 2
+    nq = 3
+    psum = PauliSum(nq)
+    add!(psum, :X, 1, 1.0)
+    add!(psum, :Z, 3, 0.5)
+    gate = PauliRotation([:Z, :X], [1, 2])
+    stock = propagate([gate], psum, [theta]; min_abs_coeff=0.0, max_weight=1)
+    vec_fused_sum = Performance.propagate([gate], VectorPauliSum(psum), [theta]; min_abs_coeff=0.0, max_weight=1, fused=true)
+    vec_fused = PauliSum(nq, Dict(zip(paulis(vec_fused_sum), coefficients(vec_fused_sum))))
+    @test vec_fused == stock
+    @test getcoeff(vec_fused_sum, :X, 1) == cos(theta)
+    @test getcoeff(vec_fused_sum, :Z, 3) == 0.5
+
+    # multi task: > 16384 terms of weight w with X on qubit 1 and identity on the last qubit, so
+    # the gate Z1 X_nq branches all of them into weight w + 1 products
+    nq = 14
+    w = 11
+    Random.seed!(3)
+    pstrs = unique([PauliString(nq, [:X; rand([:X, :Y, :Z], w - 1)], 1:w) for _ in 1:40_000])
+    @test length(pstrs) > 16384
+    vsum = VectorPauliSum(nq, [pstr.term for pstr in pstrs], rand(length(pstrs)))
+    gate = PauliRotation([:Z, :X], [1, nq])
+    stock = propagate([gate], vsum, [theta]; min_abs_coeff=0.0, max_weight=w)
+    fused = Performance.propagate([gate], vsum, [theta]; min_abs_coeff=0.0, max_weight=w, fused=true)
+    @test length(fused) == length(pstrs)
+    @test fused == stock
+end
+
+@testset "fused Vector PauliNoise truncates correctly across tasks and keeps the sorted prefix" begin
+    PB = PauliPropagation.PropagationBase
+    nq = 14
+    topo = bricklayertopology(nq; periodic=false)
+    circuit = hardwareefficientcircuit(nq, 6; topology=topo)
+    Random.seed!(9)
+    thetas = randn(countparameters(circuit))
+    big = propagate(circuit, VectorPauliSum(PauliString(nq, :Z, 3)), thetas; min_abs_coeff=1e-5)
+    @test length(big) > 16384
+
+    noise_circuit = [DepolarizingNoise(qind, 0.1 + 0.01 * qind) for qind in 1:nq]
+    min_abs_coeff = 1e-3
+    stock = propagate(noise_circuit, big; min_abs_coeff)
+    fused = Performance.propagate(noise_circuit, big; min_abs_coeff, fused=true)
+    @test length(fused) < length(big)
+    @test fused == stock
+
+    # on a merged (sorted) cache the survivors stay sorted, so the whole active range is the prefix
+    prop_cache = PropagationCache(big)
+    PB.merge!(prop_cache)
+    @test PB.sortedprefix(PB.mainsum(prop_cache)) == PB.activesize(prop_cache)
+    for gate in noise_circuit
+        PB.applymergetruncate!(gate, prop_cache; min_abs_coeff, fused=true)
+    end
+    @test PB.sortedprefix(PB.mainsum(prop_cache)) == PB.activesize(prop_cache)
+    @test issorted(view(PB.terms(PB.mainsum(prop_cache)), 1:PB.activesize(prop_cache)))
+end


### PR DESCRIPTION
## What changed

The fused `PauliRotation`, `ImaginaryPauliRotation` and `PauliNoise` overloads for `VectorPauliPropagationCache` in `src/Performance/fused_vector.jl` walked the active terms twice per gate: a dry run (`Val(false)`) that counted each thread task's output so the tasks got exact write offsets, then a real run that wrote it.

Now each task does one pass, writing its products (or noise survivors) into the **aux** arrays over its own range. That range is an upper bound, one product per term, so tasks never overlap and aux capacity (always equal to main capacity) already holds it. A parallel block copy, the new `_compactblocks!` in `src/Base/vectorbackend.jl` reusing the existing `_copyblock!`, then compacts the per-task stretches into the main arrays. For the rotation gates that means appending past `n_old`, leaving the sorted prefix intact for `xorsortedtailmerge!`; for noise it means compacting into `main[1:n_kept]` with no swap. Per-task counts replace the dry run.

The `Val{DoWrite}` toggle and the `isinf(max_weight)` early-return special case are gone from this file; `_writeandadvance!` keeps its toggle for `sortedtailmerge.jl`.

## Why

The dry run recomputed the commutation check, the product and its weight for every branching term. For 128-bit and wider strings with a finite `max_weight` that was about a third of the gate time.

## Results

Byte-identical output: verified on five propagations with noise layers (12, 40 and 100 qubits, with and without weight caps) against the previous code. The full suite passes (5165 tests).

**What "gate time" means below.** One call of `applymergetruncate!(gate, prop_cache, theta; fused=true, max_weight)` for a single two-qubit rotation, `PauliRotation([:X, :X], [1, 2])` with `theta = 0.3`, on a `VectorPauliPropagationCache` that already holds 5×10^7 sorted terms. That one call is the whole per-gate cost of the fused path: the apply pass over all terms (this PR's change), the xor sort of the appended tail, and the two-pointer merge with coefficient truncation (`min_abs_coeff = 1e-10`). It does not include growing the cache: capacity was pre-sized and touched beforehand, because a `resize!` plus first-touch page faults otherwise adds 50 ms or more that has nothing to do with either implementation. Each number is the minimum of 3 repeats on 10 threads, with the cache restored to the same input before each repeat.

The sums are synthetic but shaped like a truncated propagation: every string has random support with a weight drawn uniformly from the five values just under the cap (so weights 5 to 10 for cap 10, and so on), and with the gate on qubits 1 and 2 about 14 to 28% of the terms branch. In the capped rows the products that would exceed the cap are dropped during the apply. Times in ms:

| case | before | after |
|---|---|---|
| 30 qubits, weights 5-10, no cap | 59 | 60 |
| 30 qubits, weights 5-10, max_weight 10 | 58 | 58 |
| 64 qubits, weights 10-15, no cap | 62 | 62 |
| 64 qubits, weights 10-15, max_weight 15 | 74 | 60 |
| 128 qubits, weights 15-20, no cap | 75 | 69 |
| 128 qubits, weights 15-20, max_weight 20 | 77 | 67 |

## For the reviewer

- The `resize!` of the cache must stay after the pass: the byte-mask path reads main terms through a raw pointer that does not survive a resize. Aux contents survive `resize!` (it grows the same `Vector` objects).
- Stale products remain in `aux[1:n_old]` after the copy. Every consumer (`_tailscratch` beyond `n_new`, `_mergesortedhead!`, the generic `merge!`) writes aux before reading it.
- Dense sums with no weight cap where half the terms branch can be a few percent slower at 5×10^7 terms, because the extra write plus read of the products slightly exceeds the old cheap counting pass. With realistic caps (10 to 20) this does not show.
- The merge's own dry run in `_mergesortedhead!` is deliberately untouched: replacing it needs a compaction copy whenever any collision or truncation leaves a gap, which measured about as expensive as the pass it would replace.

## Tests added

In `test/test_performance.jl`: branching where every product is weight-dropped (single and multi task, checks the parents are scaled), and fused `PauliNoise` with real truncation on a multi-task cache including the sorted-prefix bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

